### PR TITLE
Added `toObjectTranslated()` and `toJSONTranslated()` instance method to the schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+npm-debug.log
+/coverage

--- a/lib/mongoose-i18n.js
+++ b/lib/mongoose-i18n.js
@@ -89,7 +89,7 @@
     var lastTranslatedField;
     lastTranslatedField = '';
     return schema.eachPath(function(path, config) {
-      var keys, tree, _ref;
+      var child, index, keys, tree, _i, _len, _ref, _ref1, _results;
       if (config.options.i18n && !new RegExp("^" + lastTranslatedField + "\\.[^\.]+?$").test(path)) {
         lastTranslatedField = path.replace(/^(.*?)\.([^\.]+?)$/, '$1');
         keys = path.split('.');
@@ -97,7 +97,16 @@
         while (keys.length > 2) {
           tree = tree[keys.shift()];
         }
-        return tree[keys[0]] = (_ref = tree[keys[0]]) != null ? _ref[translation] : void 0;
+        if (_.isArray(tree)) {
+          _results = [];
+          for (index = _i = 0, _len = tree.length; _i < _len; index = ++_i) {
+            child = tree[index];
+            _results.push(tree[index][keys[0]] = (_ref = tree[index][keys[0]]) != null ? _ref[translation] : void 0);
+          }
+          return _results;
+        } else {
+          return tree[keys[0]] = (_ref1 = tree[keys[0]]) != null ? _ref1[translation] : void 0;
+        }
       }
     });
   };

--- a/lib/mongoose-i18n.js
+++ b/lib/mongoose-i18n.js
@@ -1,6 +1,6 @@
 (function() {
   'use strict';
-  var Schema, debug, exports, mongoose, removePathFromSchema, _;
+  var Document, debug, exports, mongoose, removePathFromSchema, translateObject, _;
 
   _ = require('lodash');
 
@@ -8,16 +8,15 @@
 
   mongoose = require('mongoose');
 
-  Schema = mongoose.Schema;
+  Document = mongoose.Document;
 
   exports = module.exports = function(schema, options) {
     if (!_.isArray(options != null ? options.languages : void 0)) {
       throw new TypeError('Must pass an array of languages.');
     }
-    return schema.eachPath(function(path, config) {
+    schema.eachPath(function(path, config) {
       var defaultPath, vPath;
       if (config.options.i18n) {
-        delete config.options.i18n;
         removePathFromSchema(path, schema);
         _.each(options.languages, function(lang) {
           var obj;
@@ -40,6 +39,65 @@
             return this.set(defaultPath, value);
           });
         }
+      }
+    });
+    schema.methods.toObjectTranslated = function(options) {
+      var key, populated, ret, translation, _ref;
+      translation = void 0;
+      if (options != null) {
+        translation = options.translation;
+        delete options.translation;
+        if (Object.keys(options).length === 0) {
+          options = void 0;
+        }
+      }
+      ret = Document.prototype.toObject.call(this, options);
+      if (translation != null) {
+        translateObject(ret, schema, translation);
+        _ref = this.$__.populated;
+        for (key in _ref) {
+          populated = _ref[key];
+          translateObject(ret[key], populated.options.model.schema, translation);
+        }
+      }
+      return ret;
+    };
+    return schema.methods.toJSONTranslated = function(options) {
+      var key, populated, ret, translation, _ref;
+      translation = void 0;
+      if (options != null) {
+        translation = options.translation;
+        delete options.translation;
+        if (Object.keys(options).length === 0) {
+          options = void 0;
+        }
+      }
+      ret = Document.prototype.toJSON.call(this, options);
+      if (translation != null) {
+        translateObject(ret, schema, translation);
+        _ref = this.$__.populated;
+        for (key in _ref) {
+          populated = _ref[key];
+          translateObject(ret[key], populated.options.model.schema, translation);
+        }
+      }
+      return ret;
+    };
+  };
+
+  translateObject = function(object, schema, translation) {
+    var lastTranslatedField;
+    lastTranslatedField = '';
+    return schema.eachPath(function(path, config) {
+      var keys, tree, _ref;
+      if (config.options.i18n && !new RegExp("^" + lastTranslatedField + "\\.[^\.]+?$").test(path)) {
+        lastTranslatedField = path.replace(/^(.*?)\.([^\.]+?)$/, '$1');
+        keys = path.split('.');
+        tree = object;
+        while (keys.length > 2) {
+          tree = tree[keys.shift()];
+        }
+        return tree[keys[0]] = (_ref = tree[keys[0]]) != null ? _ref[translation] : void 0;
       }
     });
   };

--- a/lib/mongoose-i18n.js
+++ b/lib/mongoose-i18n.js
@@ -1,15 +1,17 @@
 (function() {
   'use strict';
-  var Schema, exports, mongoose, removePathFromSchema, _;
+  var Schema, debug, exports, mongoose, removePathFromSchema, _;
 
   _ = require('lodash');
+
+  debug = require('debug')('mongoose-i18n');
 
   mongoose = require('mongoose');
 
   Schema = mongoose.Schema;
 
   exports = module.exports = function(schema, options) {
-    if (!((options.languages != null) || _.isArray(options.languages))) {
+    if (!_.isArray(options != null ? options.languages : void 0)) {
       throw new TypeError('Must pass an array of languages.');
     }
     return schema.eachPath(function(path, config) {

--- a/package.json
+++ b/package.json
@@ -21,13 +21,20 @@
     "mongoose": "^3.8.8"
   },
   "devDependencies": {
-    "coffee-script": "^1.7.1",
+    "chai": "^1.10.0",
+    "chai-as-promised": "^4.1.1",
+    "coffee-script": "^1.8.0",
+    "debug": "^2.1.1",
     "grunt": "^0.4.4",
     "grunt-contrib-coffee": "^0.10.1",
-    "grunt-contrib-watch": "^0.6.1"
+    "grunt-contrib-watch": "^0.6.1",
+    "istanbul": "duereg/istanbul",
+    "mocha": "^2.0.1",
+    "q": "^1.1.2"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "NODE_ENV=test node_modules/.bin/mocha --compilers coffee:coffee-script/register --reporter dot test/**/*.test.coffee",
+    "coverage": "NODE_ENV=test node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- --compilers coffee:coffee-script/register --reporter dot test/**/*.test.coffee"
   },
   "keywords": [
     "Mongoose",

--- a/src/mongoose-i18n.coffee
+++ b/src/mongoose-i18n.coffee
@@ -11,6 +11,7 @@
 'use strict'
 
 _ = require 'lodash'
+debug = require('debug')('mongoose-i18n')
 mongoose = require 'mongoose'
 
 Schema = mongoose.Schema
@@ -29,7 +30,7 @@ Schema = mongoose.Schema
 # @option options {String} [defaultLanguage] the default language
 # @throws {TypeError} if languages is not set or is not an array
 exports = module.exports = (schema, options) ->
-  unless options.languages? or _.isArray(options.languages)
+  unless _.isArray(options?.languages)
     throw new TypeError 'Must pass an array of languages.'
 
   schema.eachPath (path, config) ->

--- a/src/mongoose-i18n.coffee
+++ b/src/mongoose-i18n.coffee
@@ -133,7 +133,10 @@ translateObject = (object, schema, translation) ->
 
       tree = tree[keys.shift()] while keys.length > 2
 
-      tree[keys[0]] = tree[keys[0]]?[translation]
+      if _.isArray(tree)
+        tree[index][keys[0]] = tree[index][keys[0]]?[translation] for child, index in tree
+      else
+        tree[keys[0]] = tree[keys[0]]?[translation]
 
 # Add remove method to Schema prototype
 #

--- a/test/mongoose-i18n.test.coffee
+++ b/test/mongoose-i18n.test.coffee
@@ -1,0 +1,138 @@
+chai           = require('chai')
+chaiAsPromised = require('chai-as-promised')
+debug          = require('debug')('mongoose-i18n:test')
+mongoose       = require('mongoose')
+Q              = require('q')
+i18n           = require('../src/mongoose-i18n')
+
+chai.use(chaiAsPromised)
+expect = chai.expect
+
+Schema          = mongoose.Schema
+ValidationError = mongoose.Error.ValidationError
+
+describe 'Translatable', ->
+
+    Translatable = undefined
+
+    before ->
+        mongoose.connect('mongodb://localhost/test-mongoose-i18n')
+        mongoose.connection.on 'error', (err) ->
+            console.log("MongoDB error: #{ err.message }")
+            console.log("Make sure MongoDB is up and running.")
+
+    after ->
+        mongoose.connection.db.dropDatabase()
+
+    describe 'Schema', ->
+
+        it 'should throw error if no lanuages is passed in the configuration', ->
+
+            TranslatableSchema = new Schema
+                index : Number
+                value : { type: String, i18n: true }
+
+            expect(-> TranslatableSchema.plugin(i18n)).to.throw(TypeError, /must pass an array of languages/i)
+
+        it "should throw error if languages passed in the configuration isn't an array", ->
+
+            TranslatableSchema = new Schema
+                index : Number
+                value : { type: String, i18n: true }
+
+            expect(-> TranslatableSchema.plugin(i18n, { languages: 'en_US es_ES fr_FR' })).to.throw(TypeError, /must pass an array of languages/i)
+
+        describe 'with required option set', ->
+
+            describe 'and default language set', ->
+
+                before ->
+                    TranslatableSchema = new Schema
+                        index : Number
+                        value : { type: String, i18n: true, required: true }
+
+                    TranslatableSchema.plugin(i18n, { languages: ['en_US', 'es_ES', 'fr_FR'], defaultLanguage: 'en_US' })
+                    Translatable = mongoose.model('Translatable_0_0', TranslatableSchema)
+
+                it 'should require the default language only', (done) ->
+
+                    # Todo: use the promise version of `validate()` once mongoose 3.9 is stable
+
+                    new Translatable(value: { en_US: 'Hello' }).validate (err) ->
+                        expect(err).to.be.undefined
+
+                        new Translatable(value: { es_ES: 'Hola', fr_FR: 'Bonjour', zh_HK: '你好' }).validate (err) ->
+                            expect(err).to.be.an.instanceOf(ValidationError)
+                                       .and.match(/en_US/i)
+                                       .and.match(/required/i)
+
+                            done()
+
+            describe 'and default language absent', ->
+
+                before ->
+                    TranslatableSchema = new Schema
+                        index : Number
+                        value : { type: String, i18n: true, required: true }
+
+                    TranslatableSchema.plugin(i18n, { languages: ['en_US', 'es_ES', 'fr_FR'] })
+                    Translatable = mongoose.model('Translatable_0_1', TranslatableSchema)
+
+                it 'should require all languages to be set', (done) ->
+
+                    # Todo: use the promise version of `validate()` once mongoose 3.9 is stable
+
+                    new Translatable(value: { en_US: 'Hello' }).validate (err) ->
+                        expect(err).to.be.an.instanceOf(ValidationError)
+                                   .and.match(/required/i)
+                                   .and.match(/es_ES/i)
+                                   .and.match(/fr_FR/i)
+
+                        new Translatable(value: { en_US: 'Hello', es_ES: 'Hola', fr_FR: 'Bonjour', zh_HK: '你好' }).validate (err) ->
+                            expect(err).to.be.undefined
+
+                            done()
+
+    describe 'Instance', ->
+
+        before ->
+            TranslatableSchema = new Schema
+                index  : Number
+                value  : { type: String, i18n: true }
+                value2 : { type: String, i18n: true }
+
+            TranslatableSchema.plugin(i18n, { languages: ['en_US', 'es_ES', 'fr_FR'], defaultLanguage: 'en_US' })
+            Translatable = mongoose.model('Translatable_1_0', TranslatableSchema)
+
+        it 'should store i18n fields in registered languages', ->
+
+            Translatable.create
+                index  : 0
+                value  : { en_US: 'Hello', es_ES: 'Hola', fr_FR: 'Bonjour', zh_HK: '你好' }
+                value2 : { en_US: 'Bye', es_ES: 'Adiós', fr_FR: 'Au revoir', zh_HK: '再見' }
+            .then ->
+                Translatable.findOne(index: 0).exec()
+            .then (translatable) ->
+                expect(translatable).to.have.deep.property('value.en_US').that.equals('Hello')
+                expect(translatable).to.have.deep.property('value.es_ES').that.equals('Hola')
+                expect(translatable).to.have.deep.property('value.fr_FR').that.equals('Bonjour')
+                expect(translatable).to.not.have.deep.property('value.zh_HK')
+                expect(translatable).to.have.deep.property('value2.en_US').that.equals('Bye')
+                expect(translatable).to.have.deep.property('value2.es_ES').that.equals('Adiós')
+                expect(translatable).to.have.deep.property('value2.fr_FR').that.equals('Au revoir')
+                expect(translatable).to.not.have.deep.property('value2.zh_HK')
+
+        it 'should have virtual getter and setter for the default language', ->
+            Translatable.findOne(index: 0).exec()
+            .then (translatable) ->
+                expect(translatable.value).has.property('i18n').that.equals('Hello')
+                expect(translatable.value2).has.property('i18n').that.equals('Bye')
+
+                translatable.value.i18n = 'Hi'
+                translatable.value2.i18n = 'Farewell'
+
+                Q.ninvoke(translatable, 'save').then -> Translatable.findOne(index: 0).exec()
+
+            .then (translatable) ->
+                expect(translatable).to.have.deep.property('value.en_US').that.equals('Hi')
+                expect(translatable).to.have.deep.property('value2.en_US').that.equals('Farewell')


### PR DESCRIPTION
Hi, I have added two instance methods `toObjectTranslated()` and `toJSONTranslated()` that can be used to convert the model's i18n field into a `String` in the specified language.

The object can then be translated in run time, i.e. using value from `Accept-Language` header

```coffeescript

TranslatableSchema = new mongoose.Schema(value: { type: String, i18n: true })
TranslatableSchema.plugin(i18n, { languages: ['en_US', 'es_ES', 'fr_FR'], defaultLanguage: 'en_US' })
Translatable = mongoose.model('Translatable', TranslatableSchema)

Translatable.create(value: { en_US: 'Hello', es_ES: 'Hola', fr_FR: 'Bonjour' }).then (translatable) ->
    json = translatable.toJSONTranslated() # the same as calling `toJSON()`
    json.value # { en_US: 'Hello', es_ES: 'Hola', fr_FR: 'Bonjour' }

    # Valid options for `toObject()` also works
    json = translatable.toJSONTranslated(translation: 'es_ES')
    json.value # "Hola"
```

This PR included commits in #2.