### PR TITLE
adds function support for defaultLanguage

### DIFF
--- a/lib/mongoose-i18n.js
+++ b/lib/mongoose-i18n.js
@@ -31,12 +31,18 @@
         });
         if (options.defaultLanguage != null) {
           vPath = "" + path + ".i18n";
-          defaultPath = "" + path + "." + options.defaultLanguage;
+          defaultPath = function() {
+            if (typeof options.defaultLanguage === 'function') {
+              return "" + path + "." + (options.defaultLanguage());
+            } else {
+              return "" + path + "." + options.defaultLanguage;
+            }
+          };
           schema.virtual(vPath).get(function() {
-            return this.get(defaultPath);
+            return this.get(defaultPath());
           });
           return schema.virtual(vPath).set(function(value) {
-            return this.set(defaultPath, value);
+            return this.set(defaultPath(), value);
           });
         }
       }

--- a/src/mongoose-i18n.coffee
+++ b/src/mongoose-i18n.coffee
@@ -58,15 +58,16 @@ exports = module.exports = (schema, options) ->
 
       if options.defaultLanguage?
         vPath = "#{path}.i18n"
-        defaultPath = "#{path}.#{options.defaultLanguage}"
+        defaultPath = () ->
+          return if typeof options.defaultLanguage is 'function' then "#{path}.#{options.defaultLanguage()}" else "#{path}.#{options.defaultLanguage}"
 
         # virtual getter for default language
         schema.virtual(vPath).get ->
-          return @get defaultPath
+          return @get defaultPath()
 
         # virtual setter for default language
         schema.virtual(vPath).set (value) ->
-          return @set defaultPath, value
+          return @set defaultPath(), value
 
   schema.methods.toObjectTranslated = (options) ->
       translation = undefined


### PR DESCRIPTION
this pull request adds _function_ support for `defaultLanguage` option. with it you are able to set the default language later than at schema initialisation.

this is my first attempt with coffeescript. feel free to adjust to your satisfaction.

there was a typo in the tests as well i think.
